### PR TITLE
Build nginx 1.19.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NGINX_VERSION=1.19.2
+ARG NGINX_VERSION=1.19.3
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=25f86f0bac1101b6512135eac5f93c49c63609e3

--- a/readme.md
+++ b/readme.md
@@ -5,18 +5,18 @@ This project is based on Alpine Linux, the official nginx image and an nginx mod
 As this project is based on the official [nginx image](https://hub.docker.com/_/nginx/) look for instructions there. In addition to the standard configuration directives, you'll be able to use the brotli module specific ones, see [here for official documentation](https://github.com/google/ngx_brotli#configuration-directives)
 
 ```
-docker pull macbre/nginx-brotli:1.19.2
+docker pull macbre/nginx-brotli:1.19.3
 ```
 
 ## What's inside
 
 ```
 $ docker run -it macbre/nginx-brotli nginx -V
-nginx version: nginx/1.19.2
+nginx version: nginx/1.19.3
 built by gcc 9.3.0 (Alpine 9.3.0) 
 built with OpenSSL 1.1.1g  21 Apr 2020
 TLS SNI support enabled
-configure arguments: --prefix=/etc/nginx --sbin-path=/usr/sbin/nginx --modules-path=/usr/lib/nginx/modules --conf-path=/etc/nginx/nginx.conf --error-log-path=/var/log/nginx/error.log --http-log-path=/var/log/nginx/access.log --pid-path=/var/run/nginx.pid --lock-path=/var/run/nginx.lock --http-client-body-temp-path=/var/cache/nginx/client_temp --http-proxy-temp-path=/var/cache/nginx/proxy_temp --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp --http-scgi-temp-path=/var/cache/nginx/scgi_temp --user=nginx --group=nginx --with-http_ssl_module --with-http_realip_module --with-http_addition_module --with-http_sub_module --with-http_dav_module --with-http_flv_module --with-http_mp4_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_random_index_module --with-http_secure_link_module --with-http_stub_status_module --with-http_auth_request_module --with-http_xslt_module=dynamic --with-http_image_filter_module=dynamic --with-http_geoip_module=dynamic --with-threads --with-stream --with-stream_ssl_module --with-stream_ssl_preread_module --with-stream_realip_module --with-stream_geoip_module=dynamic --with-http_slice_module --with-mail --with-mail_ssl_module --with-compat --with-file-aio --with-http_v2_module --add-module=/usr/src/ngx_brotli --with-ld-opt=-Wl,-rpath,/usr/lib --add-module=/tmp/ngx_devel_kit-0.3.1 --add-module=/tmp/lua-nginx-module-0.10.17
+configure arguments: --prefix=/etc/nginx --sbin-path=/usr/sbin/nginx --modules-path=/usr/lib/nginx/modules --conf-path=/etc/nginx/nginx.conf --error-log-path=/var/log/nginx/error.log --http-log-path=/var/log/nginx/access.log --pid-path=/var/run/nginx.pid --lock-path=/var/run/nginx.lock --http-client-body-temp-path=/var/cache/nginx/client_temp --http-proxy-temp-path=/var/cache/nginx/proxy_temp --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp --http-scgi-temp-path=/var/cache/nginx/scgi_temp --user=nginx --group=nginx --with-http_ssl_module --with-http_realip_module --with-http_addition_module --with-http_sub_module --with-http_dav_module --with-http_flv_module --with-http_mp4_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_random_index_module --with-http_secure_link_module --with-http_stub_status_module --with-http_auth_request_module --with-http_xslt_module=dynamic --with-http_image_filter_module=dynamic --with-http_geoip_module=dynamic --with-threads --with-stream --with-stream_ssl_module --with-stream_ssl_preread_module --with-stream_realip_module --with-stream_geoip_module=dynamic --with-http_slice_module --with-mail --with-mail_ssl_module --with-compat --with-file-aio --with-http_v2_module --add-module=/usr/src/ngx_brotli --with-ld-opt=-Wl,-rpath,/usr/lib --add-module=/tmp/ngx_devel_kit-0.3.1 --add-module=/tmp/lua-nginx-module-0.10.14
 ```
 
 > [nginx release notes](https://nginx.org/en/CHANGES)


### PR DESCRIPTION
https://nginx.org/en/CHANGES

```
Changes with nginx 1.19.3                                        29 Sep 2020

    *) Feature: the ngx_stream_set_module.

    *) Feature: the "proxy_cookie_flags" directive.

    *) Feature: the "userid_flags" directive.

    *) Bugfix: the "stale-if-error" cache control extension was erroneously
       applied if backend returned a response with status code 500, 502,
       503, 504, 403, 404, or 429.

    *) Bugfix: "[crit] cache file ... has too long header" messages might
       appear in logs if caching was used and the backend returned responses
       with the "Vary" header line.

    *) Workaround: "[crit] SSL_write() failed" messages might appear in logs
       when using OpenSSL 1.1.1.

    *) Bugfix: "SSL_shutdown() failed (SSL: ... bad write retry)" messages
       might appear in logs; the bug had appeared in 1.19.2.

    *) Bugfix: a segmentation fault might occur in a worker process when
       using HTTP/2 if errors with code 400 were redirected to a proxied
       location using the "error_page" directive.

    *) Bugfix: socket leak when using HTTP/2 and subrequests in the njs
       module.
```