### PR TITLE
Image for nginx 1.19.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NGINX_VERSION=1.19.4
+ARG NGINX_VERSION=1.19.6
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=25f86f0bac1101b6512135eac5f93c49c63609e3

--- a/readme.md
+++ b/readme.md
@@ -5,14 +5,14 @@ This project is based on Alpine Linux, the official nginx image and an nginx mod
 As this project is based on the official [nginx image](https://hub.docker.com/_/nginx/) look for instructions there. In addition to the standard configuration directives, you'll be able to use the brotli module specific ones, see [here for official documentation](https://github.com/google/ngx_brotli#configuration-directives)
 
 ```
-docker pull macbre/nginx-brotli:1.19.5
+docker pull macbre/nginx-brotli:1.19.6
 ```
 
 ## What's inside
 
 ```
 $ docker run -it macbre/nginx-brotli nginx -V
-nginx version: nginx/1.19.5
+nginx version: nginx/1.19.6
 built by gcc 9.3.0 (Alpine 9.3.0) 
 built with OpenSSL 1.1.1i  8 Dec 2020
 TLS SNI support enabled


### PR DESCRIPTION
```
Changes with nginx 1.19.6                                        15 Dec 2020

    *) Bugfix: "no live upstreams" errors if a "server" inside "upstream"
       block was marked as "down".

    *) Bugfix: a segmentation fault might occur in a worker process if HTTPS
       was used; the bug had appeared in 1.19.5.

    *) Bugfix: nginx returned the 400 response on requests like
       "GET http://example.com?args HTTP/1.0".

    *) Bugfix: in the ngx_http_flv_module and ngx_http_mp4_module.
       Thanks to Chris Newton.
```