### PR TITLE
Use the Docker image as a source of cache layers

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -16,8 +16,7 @@ jobs:
 
     - name: Build the Docker image
       env:
-        CACHE_IMAGE: docker.io/macbre/nginx-brotli:latest
-        DOCKER_BUILDKIT: 1
+        CACHE_IMAGE: macbre/nginx-brotli:latest
       run: |
         # use this image as a source of cache layers to speed up subsequent builds
         # @see https://testdriven.io/blog/faster-ci-builds-with-docker-cache/
@@ -25,8 +24,7 @@ jobs:
 
         # build an image using the current Docker Hub container image
         docker build . \
-          --tag $CACHE_IMAGE \
-          --build-arg BUILDKIT_INLINE_CACHE=1 \
+          --tag ${{ github.repository }} \
           --cache-from $CACHE_IMAGE
         docker images
 
@@ -42,7 +40,7 @@ jobs:
           -v "$PWD/tests/env.conf":/etc/nginx/main.d/env.conf:ro \
           --env FOO=foo-test-value \
           --name test_nginx \
-          -t $CACHE_IMAGE
+          -t ${{ github.repository }}
 
         sleep 2; docker ps
         curl -v --compressed 0.0.0.0:8888 2>&1 | tee /tmp/out

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -9,22 +9,25 @@ on:
 jobs:
 
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Build the Docker image
+      env:
+        CACHE_IMAGE: macbre/nginx-brotli:latest
+        DOCKER_BUILDKIT: 1
       run: |
         # use this image as a source of cache layers to speed up subsequent builds
-        docker pull macbre/nginx-brotli:latest
-        
+        # @see https://testdriven.io/blog/faster-ci-builds-with-docker-cache/
+        docker pull $CACHE_IMAGE
+
         # build an image using the current Docker Hub container image
         docker build . \
-          --tag ${{ github.repository }} \
+          --tag $CACHE_IMAGE \
           --build-arg BUILDKIT_INLINE_CACHE=1 \
-          --cache-from macbre/nginx-brotli:latest
+          --cache-from $CACHE_IMAGE
         docker images
 
     - name: Run nginx -V
@@ -32,7 +35,7 @@ jobs:
 
     - name: Serve a static asset
       run: |
-        docker run --detach --rm -p 0.0.0.0:8888:80 -v "$PWD/tests":/static:ro  -v "$PWD/tests/static.conf":/etc/nginx/conf.d/static.conf:ro -v "$PWD/tests/env.conf":/etc/nginx/main.d/env.conf:ro --env FOO=foo-test-value --name test_nginx -t ${{ github.repository }}
+        docker run --detach --rm -p 0.0.0.0:8888:80 -v "$PWD/tests":/static:ro  -v "$PWD/tests/static.conf":/etc/nginx/conf.d/static.conf:ro -v "$PWD/tests/env.conf":/etc/nginx/main.d/env.conf:ro --env FOO=foo-test-value --name test_nginx -t $CACHE)IMAGE
         sleep 2; docker ps
         curl -v --compressed 0.0.0.0:8888 2>&1 | tee /tmp/out
 

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -17,7 +17,9 @@ jobs:
 
     - name: Build the Docker image
       run: |
-        docker build . --tag ${{ github.repository }}
+        docker build . \
+          --tag ${{ github.repository }} \
+          --cache-from macbre/nginx-brotli:latest
         docker images
 
     - name: Run nginx -V

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -17,6 +17,10 @@ jobs:
 
     - name: Build the Docker image
       run: |
+        # use this image as a source of cache layers to speed up subsequent builds
+        docker pull macbre/nginx-brotli:latest
+        
+        # build an image using the current Docker Hub container image
         docker build . \
           --tag ${{ github.repository }} \
           --build-arg BUILDKIT_INLINE_CACHE=1 \

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -21,14 +21,15 @@ jobs:
         # @see https://docs.docker.com/develop/develop-images/build_enhancements/
         COMPOSE_DOCKER_CLI_BUILD: "1"
         DOCKER_BUILDKIT: "1"
-      run: |
-        # use this image as a source of cache layers to speed up subsequent builds
-        # @see https://testdriven.io/blog/faster-ci-builds-with-docker-cache/
-        docker pull $CACHE_IMAGE
 
-        # build an image using the current Docker Hub container image
+      run: |
+        # build an image using the current Docker Hub container image as a layers cache
+
+        # @see https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources
+        # no need to "docker pull $CACHE_IMAGE", BuildKit is clever enough to pull it when needed
         docker build . \
           --tag ${{ github.repository }} \
+           --build-arg BUILDKIT_INLINE_CACHE=1 \
           --cache-from $CACHE_IMAGE
         docker images
 

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Build the Docker image
       env:
-        CACHE_IMAGE: macbre/nginx-brotli:latest
+        CACHE_IMAGE: docker.io/macbre/nginx-brotli:latest
         DOCKER_BUILDKIT: 1
       run: |
         # use this image as a source of cache layers to speed up subsequent builds

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -19,6 +19,7 @@ jobs:
       run: |
         docker build . \
           --tag ${{ github.repository }} \
+          --build-arg BUILDKIT_INLINE_CACHE=1 \
           --cache-from macbre/nginx-brotli:latest
         docker images
 

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -35,7 +35,15 @@ jobs:
 
     - name: Serve a static asset
       run: |
-        docker run --detach --rm -p 0.0.0.0:8888:80 -v "$PWD/tests":/static:ro  -v "$PWD/tests/static.conf":/etc/nginx/conf.d/static.conf:ro -v "$PWD/tests/env.conf":/etc/nginx/main.d/env.conf:ro --env FOO=foo-test-value --name test_nginx -t $CACHE)IMAGE
+        docker run --detach --rm \
+          -p 0.0.0.0:8888:80 \
+          -v "$PWD/tests":/static:ro \
+          -v "$PWD/tests/static.conf":/etc/nginx/conf.d/static.conf:ro \
+          -v "$PWD/tests/env.conf":/etc/nginx/main.d/env.conf:ro \
+          --env FOO=foo-test-value \
+          --name test_nginx \
+          -t $CACHE_IMAGE
+
         sleep 2; docker ps
         curl -v --compressed 0.0.0.0:8888 2>&1 | tee /tmp/out
 

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -17,6 +17,10 @@ jobs:
     - name: Build the Docker image
       env:
         CACHE_IMAGE: macbre/nginx-brotli:latest
+        
+        # @see https://docs.docker.com/develop/develop-images/build_enhancements/
+        COMPOSE_DOCKER_CLI_BUILD: "1"
+        DOCKER_BUILDKIT: "1"
       run: |
         # use this image as a source of cache layers to speed up subsequent builds
         # @see https://testdriven.io/blog/faster-ci-builds-with-docker-cache/


### PR DESCRIPTION
See https://testdriven.io/blog/faster-ci-builds-with-docker-cache/

----

* https://www.docker.com/blog/advanced-dockerfiles-faster-builds-and-smaller-images-using-buildkit-and-multistage-builds/
* https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources