### PR TITLE
Build nginx 1.19.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NGINX_VERSION=1.19.6
+ARG NGINX_VERSION=1.19.7
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=9aec15e2aa6feea2113119ba06460af70ab3ea62

--- a/readme.md
+++ b/readme.md
@@ -1,20 +1,20 @@
 ## What is this?
-This project is based on Alpine Linux, the official nginx image and an nginx module that provides static and dynamic brotli compression. [Brotli](https://github.com/google/brotli) and the [nginx brotli module ](https://github.com/google/ngx_brotli) are built by Google.
+This project is based on Alpine Linux, the official nginx image and an nginx module that provides static and dynamic **brotli** compression. [Brotli](https://github.com/google/brotli) and the [nginx brotli module ](https://github.com/google/ngx_brotli) are built by Google. **SSL configuration** provides **Grade A+** handling.
 
 ## How to use this image
 As this project is based on the official [nginx image](https://hub.docker.com/_/nginx/) look for instructions there. In addition to the standard configuration directives, you'll be able to use the brotli module specific ones, see [here for official documentation](https://github.com/google/ngx_brotli#configuration-directives)
 
 ```
-docker pull macbre/nginx-brotli:1.19.6
+docker pull macbre/nginx-brotli:1.19.7
 ```
 
 ## What's inside
 
 ```
 $ docker run -it macbre/nginx-brotli nginx -V
-nginx version: nginx/1.19.6
+nginx version: nginx/1.19.7
 built by gcc 9.3.0 (Alpine 9.3.0) 
-built with OpenSSL 1.1.1i  8 Dec 2020
+built with OpenSSL 1.1.1j  16 Feb 2021 (running with OpenSSL 1.1.1i  8 Dec 2020)
 TLS SNI support enabled
 configure arguments: --prefix=/etc/nginx --sbin-path=/usr/sbin/nginx --modules-path=/usr/lib/nginx/modules --conf-path=/etc/nginx/nginx.conf --error-log-path=/var/log/nginx/error.log --http-log-path=/var/log/nginx/access.log --pid-path=/var/run/nginx.pid --lock-path=/var/run/nginx.lock --http-client-body-temp-path=/var/cache/nginx/client_temp --http-proxy-temp-path=/var/cache/nginx/proxy_temp --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp --http-scgi-temp-path=/var/cache/nginx/scgi_temp --user=nginx --group=nginx --with-http_ssl_module --with-http_realip_module --with-http_addition_module --with-http_sub_module --with-http_dav_module --with-http_flv_module --with-http_mp4_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_random_index_module --with-http_secure_link_module --with-http_stub_status_module --with-http_auth_request_module --with-http_xslt_module=dynamic --with-http_image_filter_module=dynamic --with-http_geoip_module=dynamic --with-threads --with-stream --with-stream_ssl_module --with-stream_ssl_preread_module --with-stream_realip_module --with-stream_geoip_module=dynamic --with-http_slice_module --with-mail --with-mail_ssl_module --with-compat --with-file-aio --with-http_v2_module --add-module=/usr/src/ngx_brotli --with-ld-opt=-Wl,-rpath,/usr/lib --add-module=/tmp/ngx_devel_kit-0.3.1 --add-module=/tmp/lua-nginx-module-0.10.14
 ```


### PR DESCRIPTION
```
Changes with nginx 1.19.7                                        16 Feb 2021

    *) Change: connections handling in HTTP/2 has been changed to better
       match HTTP/1.x; the "http2_recv_timeout", "http2_idle_timeout", and
       "http2_max_requests" directives have been removed, the
       "keepalive_timeout" and "keepalive_requests" directives should be
       used instead.

    *) Change: the "http2_max_field_size" and "http2_max_header_size"
       directives have been removed, the "large_client_header_buffers"
       directive should be used instead.

    *) Feature: now, if free worker connections are exhausted, nginx starts
       closing not only keepalive connections, but also connections in
       lingering close.

    *) Bugfix: "zero size buf in output" alerts might appear in logs if an
       upstream server returned an incorrect response during unbuffered
       proxying; the bug had appeared in 1.19.1.

    *) Bugfix: HEAD requests were handled incorrectly if the "return"
       directive was used with the "image_filter" or "xslt_stylesheet"
       directives.

    *) Bugfix: in the "add_trailer" directive.
```