### PR TITLE
nginx 1.19.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NGINX_VERSION=1.19.7
+ARG NGINX_VERSION=1.19.8
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=9aec15e2aa6feea2113119ba06460af70ab3ea62


### PR DESCRIPTION
```
Changes with nginx 1.19.8                                        09 Mar 2021

    *) Feature: flags in the "proxy_cookie_flags" directive can now contain
       variables.

    *) Feature: the "proxy_protocol" parameter of the "listen" directive,
       the "proxy_protocol" and "set_real_ip_from" directives in mail proxy.

    *) Bugfix: HTTP/2 connections were immediately closed when using
       "keepalive_timeout 0"; the bug had appeared in 1.19.7.

    *) Bugfix: some errors were logged as unknown if nginx was built with
       glibc 2.32.

    *) Bugfix: in the eventport method.
```