### PR TITLE
Use nginx-1.19.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NGINX_VERSION=1.19.8
+ARG NGINX_VERSION=1.19.9
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=9aec15e2aa6feea2113119ba06460af70ab3ea62

--- a/readme.md
+++ b/readme.md
@@ -7,16 +7,16 @@ Stable and up-to-date [nginx](https://nginx.org/en/CHANGES) with [Google's `brot
 As this project is based on the official [nginx image](https://hub.docker.com/_/nginx/) look for instructions there. In addition to the standard configuration directives, you'll be able to use the brotli module specific ones, see [here for official documentation](https://github.com/google/ngx_brotli#configuration-directives)
 
 ```
-docker pull macbre/nginx-brotli:1.19.8
+docker pull macbre/nginx-brotli:1.19.9
 ```
 
 ## What's inside
 
 ```
 $ docker run -it macbre/nginx-brotli nginx -V
-nginx version: nginx/1.19.8
+nginx version: nginx/1.19.9
 built by gcc 10.2.1 20201203 (Alpine 10.2.1_pre1) 
-built with OpenSSL 1.1.1j  16 Feb 2021
+built with OpenSSL 1.1.1k  25 Mar 2021
 TLS SNI support enabled
 configure arguments: --prefix=/etc/nginx --sbin-path=/usr/sbin/nginx --modules-path=/usr/lib/nginx/modules --conf-path=/etc/nginx/nginx.conf --error-log-path=/var/log/nginx/error.log --http-log-path=/var/log/nginx/access.log --pid-path=/var/run/nginx.pid --lock-path=/var/run/nginx.lock --http-client-body-temp-path=/var/cache/nginx/client_temp --http-proxy-temp-path=/var/cache/nginx/proxy_temp --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp --http-scgi-temp-path=/var/cache/nginx/scgi_temp --user=nginx --group=nginx --with-http_ssl_module --with-http_realip_module --with-http_addition_module --with-http_sub_module --with-http_dav_module --with-http_flv_module --with-http_mp4_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_random_index_module --with-http_secure_link_module --with-http_stub_status_module --with-http_auth_request_module --with-http_xslt_module=dynamic --with-http_image_filter_module=dynamic --with-http_geoip_module=dynamic --with-threads --with-stream --with-stream_ssl_module --with-stream_ssl_preread_module --with-stream_realip_module --with-stream_geoip_module=dynamic --with-http_slice_module --with-mail --with-mail_ssl_module --with-compat --with-file-aio --with-http_v2_module --add-module=/usr/src/ngx_brotli --with-ld-opt=-Wl,-rpath,/usr/lib --add-module=/tmp/ngx_devel_kit-0.3.1 --add-module=/tmp/lua-nginx-module-0.10.14
 ```


### PR DESCRIPTION
```
Changes with nginx 1.19.9                                        30 Mar 2021

    *) Bugfix: nginx could not be built with the mail proxy module, but
       without the ngx_mail_ssl_module; the bug had appeared in 1.19.8.

    *) Bugfix: "upstream sent response body larger than indicated content
       length" errors might occur when working with gRPC backends; the bug
       had appeared in 1.19.1.

    *) Bugfix: nginx might not close a connection till keepalive timeout
       expiration if the connection was closed by the client while
       discarding the request body.

    *) Bugfix: nginx might not detect that a connection was already closed
       by the client when waiting for auth_delay or limit_req delay, or when
       working with backends.

    *) Bugfix: in the eventport method.
```