### PR TITLE
Add more h3 versions in alt-svc header

### DIFF
--- a/tests/https.conf
+++ b/tests/https.conf
@@ -19,7 +19,7 @@ server {
     ssl_early_data on;
 
     # Add Alt-Svc header to negotiate HTTP/3.
-    add_header alt-svc 'h3=":8889"; ma=86400';
+    add_header alt-svc 'h3-27=":8889"; ma=86400, h3-28=":8889"; ma=86400, h3-29=":8889"; ma=86400';
 
     location / {
         root   /static;


### PR DESCRIPTION
Tested with Firefox 88 (with [`network.http.http3.enabled` flag](https://developers.cloudflare.com/http3/firefox) set to true).