### PR TITLE
Bring pack Perl module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ ARG CONFIG="\
 		--with-http_xslt_module=dynamic \
 		--with-http_image_filter_module=dynamic \
 		--with-http_geoip_module=dynamic \
+		--with-http_perl_module=dynamic \
 		--with-threads \
 		--with-stream \
 		--with-stream_ssl_module \
@@ -75,6 +76,7 @@ RUN \
 		libxslt-dev \
 		gd-dev \
 		geoip-dev \
+		perl-dev \
 	&& apk add --no-cache --virtual .brotli-build-deps \
 		autoconf \
 		libtool \
@@ -156,6 +158,7 @@ COPY --from=base /etc/nginx /etc/nginx
 COPY --from=base /usr/lib/nginx/modules/*.so /usr/lib/nginx/modules/
 COPY --from=base /usr/sbin/nginx /usr/sbin/
 COPY --from=base /usr/share/nginx/html/* /usr/share/nginx/html/
+COPY --from=base /usr/local/lib/perl5/site_perl /usr/local/lib/perl5/site_perl
 COPY --from=base /usr/bin/envsubst /usr/local/bin/envsubst
 COPY --from=base /etc/ssl/dhparam.pem /etc/ssl/dhparam.pem
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -177,6 +177,9 @@ RUN \
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY ssl_common.conf /etc/nginx/conf.d/ssl_common.conf
 
+# test the basic configuration
+RUN nginx -V; nginx -t
+
 EXPOSE 80 443
 
 STOPSIGNAL SIGTERM

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,4 +1,3 @@
-
 user  nginx;
 worker_processes  1;
 

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ docker pull ghcr.io/macbre/nginx-brotli:latest
 
 ```
 $ docker run -it macbre/nginx-brotli nginx -V
-nginx version: nginx/1.19.6 (quiche-4aafa65)
+nginx version: nginx/1.19.6 (quiche-5afe288)
 built by gcc 10.2.1 20201203 (Alpine 10.2.1_pre1) 
 built with OpenSSL 1.1.1 (compatible; BoringSSL) (running with BoringSSL)
 TLS SNI support enabled
@@ -58,6 +58,7 @@ configure arguments:
 	--with-http_xslt_module=dynamic 
 	--with-http_image_filter_module=dynamic 
 	--with-http_geoip_module=dynamic 
+	--with-http_perl_module=dynamic 
 	--with-threads 
 	--with-stream 
 	--with-stream_ssl_module 
@@ -74,7 +75,7 @@ configure arguments:
 	--with-openssl=/usr/src/quiche/deps/boringssl 
 	--with-quiche=/usr/src/quiche 
 	--add-module=/usr/src/ngx_brotli 
-	--build=quiche-4aafa65
+	--build=quiche-5afe288
 ```
 
 ## SSL Grade A+ handling


### PR DESCRIPTION
* [x] revert commit 9cd3e1fd42e798e0126992206ffa9eec8e351d6d.
* [x] README updated - be04051

Resolves #36 // cc @ibrunotome 

## Image size

With Perl:

```
REPOSITORY       TAG         IMAGE ID       CREATED        SIZE
macbre/nginx     latest      c4b1119c9516   1 second ago   56.7MB
```

Without Perl:

```
REPOSITORY       TAG         IMAGE ID       CREATED         SIZE
macbre/nginx     latest      a02c9e70c8a3   2 seconds ago   21.9MB
```

The size grew significantly, but it's still in reasonable limits.

## Dynamic modules

```
$ docker run -it macbre/nginx:perl sh
/ # ls /etc/nginx/modules/
ngx_http_geoip_module.so         ngx_http_image_filter_module.so  ngx_http_perl_module.so          ngx_http_xslt_filter_module.so   ngx_stream_geoip_module.so
```